### PR TITLE
* Removed the star from every pod as when doing pod install it drops …

### DIFF
--- a/ios/ViroReact.podspec
+++ b/ios/ViroReact.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.license             = {:type => 'Copyright', :text => "Copyright 2018 ViroMedia, Inc" }
   s.author              = 'Viro Media'
   s.requires_arc        = true
-  s.platform            = :ios, '10.0'*
+  s.platform            = :ios, '10.0'
   s.dependency 'React'
 end

--- a/ios/ViroReact_static_lib.podspec
+++ b/ios/ViroReact_static_lib.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.license             = {:type => 'Copyright', :text => "Copyright 2018 ViroMedia, Inc" }
   s.author              = 'Viro Media'
   s.requires_arc        = true
-  s.platform            = :ios, '10.0'*
+  s.platform            = :ios, '10.0'
   s.dependency 'React'
 end

--- a/ios/dist/ViroRenderer/ViroKit.podspec
+++ b/ios/dist/ViroRenderer/ViroKit.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.license             = {:type => 'Copyright', :text => "Copyright 2018 ViroMedia, Inc" }
   s.author              = 'Viro Media'
   s.requires_arc        = true
-  s.platform            = :ios, '10.0'*
+  s.platform            = :ios, '10.0'
   s.dependency 'React'
 end

--- a/ios/dist/ViroRenderer/static_lib/ViroKit_static_lib.podspec
+++ b/ios/dist/ViroRenderer/static_lib/ViroKit_static_lib.podspec
@@ -8,5 +8,5 @@ Pod::Spec.new do |s|
   s.license             = {:type => 'Copyright', :text => "Copyright 2018 ViroMedia, Inc" }
   s.author              = 'Viro Media'
   s.requires_arc        = true
-  s.platform            = :ios, '10.0'*
+  s.platform            = :ios, '10.0'
 end

--- a/ios/dist/podFile/Podfile
+++ b/ios/dist/podFile/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '10.0'*
+platform :ios, '10.0'
 target 'VIRO_PROJECT_NAME' do
   use_frameworks!
   pod 'ViroReact', :path => '../node_modules/react-viro/ios/'

--- a/ios/dist/static_lib/ViroReact.podspec
+++ b/ios/dist/static_lib/ViroReact.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.license             = {:type => 'Copyright', :text => "Copyright 2018 ViroMedia, Inc" }
   s.author              = 'Viro Media'
   s.requires_arc        = true
-  s.platform            = :ios, '10.0'*
+  s.platform            = :ios, '10.0'
   s.dependency 'React'
 end


### PR DESCRIPTION
…the following error:

Removing star from podfile react-viro

[!] Invalid `Podfile` file:
[!] Invalid `ViroReact_static_lib.podspec` file: syntax error, unexpected tSTRING_BEG, expecting end
  s.dependency 'React'
               ^
/react-native/viro-testbed/node_modules/react-viro/ios/ViroReact_static_lib.podspec:19: syntax error, unexpected end, expecting end-of-input.

 #  from /react-native/viro-testbed/node_modules/react-viro/ios/ViroReact_static_lib.podspec:18
 #  -------------------------------------------
 #    s.platform            = :ios, '10.0'*
 >    s.dependency 'React'
 #  end
 #  -------------------------------------------
.

 #  from /react-native/viro-testbed/ios/Podfile:12
 #  -------------------------------------------
 #
 >    config = use_native_modules!
 #
 #  -------------------------------------------
giv:ios itstequilabby$ pod install
    WARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
    Consider adding the following to ~/.profile:

    export LANG=en_US.UTF-8

Ignoring digest-crc-0.6.1 because its extensions are not built. Try: gem pristine digest-crc --version 0.6.1
Ignoring ffi-1.13.1 because its extensions are not built. Try: gem pristine ffi --version 1.13.1
Ignoring unf_ext-0.0.7.7 because its extensions are not built. Try: gem pristine unf_ext --version 0.0.7.7

[!] Invalid `Podfile` file:
[!] Invalid `ViroReact_static_lib.podspec` file: syntax error, unexpected tSTRING_BEG, expecting end
  s.dependency 'React'
               ^
/react-native/viro-testbed/node_modules/react-viro/ios/ViroReact_static_lib.podspec:19: syntax error, unexpected end, expecting end-of-input.

 #  from /react-native/viro-testbed/node_modules/react-viro/ios/ViroReact_static_lib.podspec:18
 #  -------------------------------------------
 #    s.platform            = :ios, '10.0'*
 >    s.dependency 'React'
 #  end
 #  -------------------------------------------
.

 #  from /react-native/viro-testbed/ios/Podfile:12
 #  -------------------------------------------
 #
 >    config = use_native_modules!
 #
 #  -------------------------------------------