### PR TITLE
Removing references to fbjs

### DIFF
--- a/components/Animation/ViroAnimationValidation.js
+++ b/components/Animation/ViroAnimationValidation.js
@@ -15,7 +15,6 @@ import React from 'react';
 import PropTypes from 'prop-types'
 
 var AnimationPropTypes = require('./ViroAnimationPropTypes');
-var invariant = require('fbjs/lib/invariant');
 
 class ViroAnimationValidation {
   static validateAnimationProp(prop, animationName, animation, caller) {
@@ -89,11 +88,15 @@ class ViroAnimationValidation {
 }
 
 var animationError = function(message1, animation, caller?, message2?) {
-  invariant(
-    false,
-    message1 + '\n' + (caller || '<<unknown>>') + ': ' +
-    JSON.stringify(animation, null, '  ') + (message2 || '')
-  );
+  const format = 
+    `${message1}\n` + 
+    `${caller || '<<unknown>>'}: ` + 
+    JSON.stringify(animation, null, '  ') + 
+    (message2 || '');
+  const error = new Error(format);
+  error.name = 'Invariant Violation';
+  error.framesToPop = 1; // Skip invariant error's own stack frame.
+  throw error;
 };
 
 var allAnimationTypes = {};

--- a/components/Material/MaterialValidation.js
+++ b/components/Material/MaterialValidation.js
@@ -15,7 +15,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 var MaterialPropTypes = require('./MaterialPropTypes');
-var invariant = require('fbjs/lib/invariant');
 
 class MaterialValidation {
 
@@ -69,11 +68,15 @@ class MaterialValidation {
 }
 
 var materialError = function(message1, material, caller?, message2?) {
-  invariant(
-    false,
-    message1 + '\n' + (caller || '<<unknown>>') + ': ' +
-    JSON.stringify(material, null, '  ') + (message2 || '')
-  );
+  const format = 
+    `${message1}\n` + 
+    `${caller || '<<unknown>>'}: ` + 
+    JSON.stringify(material, null, '  ') + 
+    (message2 || '');
+  const error = new Error(format);
+  error.name = 'Invariant Violation';
+  error.framesToPop = 1; // Skip invariant error's own stack frame.
+  throw error;
 };
 
 var allMaterialTypes = {};

--- a/components/Material/ViroMaterials.js
+++ b/components/Material/ViroMaterials.js
@@ -14,9 +14,7 @@ import resolveAssetSource from "react-native/Libraries/Image/resolveAssetSource"
 import assetRegistry from "react-native/Libraries/Image/AssetRegistry"
 
 var MaterialManager = require('react-native').NativeModules.VRTMaterialManager;
-var MaterialPropTypes = require('./MaterialPropTypes');
 var MaterialValidation = require('./MaterialValidation');
-var invariant = require('fbjs/lib/invariant');
 var processColor = require('react-native').processColor;
 
 class ViroMaterials {

--- a/readmes/INSTALL.md
+++ b/readmes/INSTALL.md
@@ -10,12 +10,6 @@ The steps below are for manually installing and linking the library to an existi
 $ npm install --save @viro-community/react-viro
 ```
 
-You will also need `fbjs`, which is currently an un-declared dependency of react-viro (we will look to remove this in future releases).
-
-```console
-$ npm install --save fbjs
-```
-
 ## Linking (You _must_ do this - we do not support auto-linking)
 
 If you're unsure about which file to edit or where to put specified the lines, we have added links to how this is done in our [starter-kit](https://github.com/ViroCommunity/starter-kit) repo.


### PR DESCRIPTION
`fbjs` is used in two places in order to raise `Invariant Violation` errors.

Depending on how the project is interpreted by metro (this seems to happen in RN 0.64.0) it does pick up on the usage of `fbjs`, however it isn't a dependency of the project, so bundling fails. (Was `fbjs` pulled in by RN in previous versions? Unsure. It certainly isn't on 64...)

Rather than add a dependency for two lines of code, I've removed the references, and replaced them with the equivalent errors being thrown manually, as the change is tiny.