### PR TITLE
Update INSTALL_IOS.md

### DIFF
--- a/readmes/INSTALL_IOS.md
+++ b/readmes/INSTALL_IOS.md
@@ -3,7 +3,7 @@
 1. Add the following lines to your `ios/Podfile` below `use_react_native!(:path => config["reactNativePath"])`:
 
    ```yaml
-   pod 'ViroReact', :path => '../node_modules/@viro-community/react-viro/ios/'
+   pod 'ViroReact', :path => '../node_modules/@viro-community/react-viro/ios'
    pod 'ViroKit', :path => '../node_modules/@viro-community/react-viro/ios/dist/ViroRenderer/'
    ```
 


### PR DESCRIPTION
```console
Analyzing dependencies
[!] There are multiple dependencies with different sources for `ViroReact` in `Podfile`:

- ViroReact (from `../node_modules/@viro-community/react-viro/ios`)
- ViroReact (from `../node_modules/@viro-community/react-viro/ios/`)
```

I've had issues with `pod install` when the extra slash is on the back of this. Not sure why this matters, but changing it fixes a pod install.