### PR TITLE
Remove unnecessary logging from Viro3DObject

### DIFF
--- a/components/Viro3DObject.tsx
+++ b/components/Viro3DObject.tsx
@@ -53,8 +53,6 @@ export class Viro3DObject extends ViroBase<Props> {
       resolveAssetSource(resource)
     );
 
-    console.log("RESOURCES", resources);
-
     // Since materials and transformBehaviors can be either a string or an array, convert the string to a 1-element array.
     const materials =
       typeof this.props.materials === "string"


### PR DESCRIPTION
This line feeds the console with "RESOURCE undefined" lines, and it's pretty annoying especially when debugging. Idk, if this were here for a reason or not, but it does not seem very useful.