### PR TITLE
Fix for 'Tried to register two views with the same name VRTQuad' in ViroSurface

### DIFF
--- a/components/ViroSurface.tsx
+++ b/components/ViroSurface.tsx
@@ -96,7 +96,7 @@ export class ViroSurface extends ViroBase<Props> {
 }
 
 var VRTSurface = requireNativeComponent(
-  "VRTQuad",
+  "VRTSurface",
   // @ts-ignore
   ViroSurface,
   {


### PR DESCRIPTION
Fix for error "Tried to register two views with the same name VRTQuad" 