### PR TITLE
fix(ViroARSceneNavigator): _project() method throwing error

### DIFF
--- a/components/AR/ViroARSceneNavigator.tsx
+++ b/components/AR/ViroARSceneNavigator.tsx
@@ -28,7 +28,6 @@ import {
   ViroSceneDictionary,
 } from "../Types/ViroUtils";
 
-
 const ViroARSceneNavigatorModule = NativeModules.VRTARSceneNavigatorModule;
 
 let mathRandomOffset = 0;
@@ -152,12 +151,25 @@ export class ViroARSceneNavigator extends React.Component<Props, State> {
    * @param point
    * @returns
    */
-  async _project(point: Viro3DPoint) {
+  _project = async (point: Viro3DPoint) => {
     return await ViroARSceneNavigatorModule.project(
       findNodeHandle(this),
       point
     );
-  }
+  };
+
+  /**
+   * TODO: Document _unproject
+   *
+   * @param point
+   * @returns
+   */
+  _unproject = async (point: Viro3DPoint) => {
+    return await ViroARSceneNavigatorModule.unproject(
+      findNodeHandle(this),
+      point
+    );
+  };
 
   /**
    * Gets a random tag string.
@@ -504,19 +516,6 @@ export class ViroARSceneNavigator extends React.Component<Props, State> {
     }
     // Unable to find the given sceneTag, return -1
     return -1;
-  };
-
-  /**
-   * TODO: Document _unproject
-   *
-   * @param point
-   * @returns
-   */
-  _unproject = async (point: Viro3DPoint) => {
-    return await ViroARSceneNavigatorModule.unproject(
-      findNodeHandle(this),
-      point
-    );
   };
 
   /**

--- a/dist/components/AR/ViroARSceneNavigator.d.ts
+++ b/dist/components/AR/ViroARSceneNavigator.d.ts
@@ -83,7 +83,14 @@ export declare class ViroARSceneNavigator extends React.Component<Props, State> 
      * @param point
      * @returns
      */
-    _project(point: Viro3DPoint): Promise<any>;
+    _project: (point: Viro3DPoint) => Promise<any>;
+    /**
+     * TODO: Document _unproject
+     *
+     * @param point
+     * @returns
+     */
+    _unproject: (point: Viro3DPoint) => Promise<any>;
     /**
      * Gets a random tag string.
      *
@@ -190,13 +197,6 @@ export declare class ViroARSceneNavigator extends React.Component<Props, State> 
      * @returns the index of the scene
      */
     getSceneIndex: (sceneTag: string) => number;
-    /**
-     * TODO: Document _unproject
-     *
-     * @param point
-     * @returns
-     */
-    _unproject: (point: Viro3DPoint) => Promise<any>;
     /**
      * [iOS Only]
      *

--- a/dist/components/AR/ViroARSceneNavigator.js
+++ b/dist/components/AR/ViroARSceneNavigator.js
@@ -110,9 +110,18 @@ class ViroARSceneNavigator extends React.Component {
      * @param point
      * @returns
      */
-    async _project(point) {
+    _project = async (point) => {
         return await ViroARSceneNavigatorModule.project((0, react_native_1.findNodeHandle)(this), point);
-    }
+    };
+    /**
+     * TODO: Document _unproject
+     *
+     * @param point
+     * @returns
+     */
+    _unproject = async (point) => {
+        return await ViroARSceneNavigatorModule.unproject((0, react_native_1.findNodeHandle)(this), point);
+    };
     /**
      * Gets a random tag string.
      *
@@ -402,15 +411,6 @@ class ViroARSceneNavigator extends React.Component {
         }
         // Unable to find the given sceneTag, return -1
         return -1;
-    };
-    /**
-     * TODO: Document _unproject
-     *
-     * @param point
-     * @returns
-     */
-    _unproject = async (point) => {
-        return await ViroARSceneNavigatorModule.unproject((0, react_native_1.findNodeHandle)(this), point);
     };
     /**
      * [iOS Only]


### PR DESCRIPTION
This change addresses a bug where the this context was lost due to _project method not being an arrow function.
Moved _unproject next to _project method for convenience.

This resolves #379