### PR TITLE
Feat: Add validation for backticks in Kotlin package names

### DIFF
--- a/plugins/withViroAndroid.ts
+++ b/plugins/withViroAndroid.ts
@@ -52,16 +52,24 @@ const withBranchAndroid: ConfigPlugin<ViroConfigurationOptions> = (config) => {
       }
 
       fs.readFile(mainApplicationPath, "utf-8", (err, data) => {
+        const packageName = config?.android?.package;
         if (isJava) {
           data = insertLinesHelper(
             "import com.viromedia.bridge.ReactViroPackage;",
-            `package ${config?.android?.package};`,
+            `package ${packageName};`,
             data
           );
         } else {
+          // Handle Backticks in package names for Kotlin
+          const packageMatch = data.match(/package\s+[\w.`]+/);
+          if (!packageMatch) {
+            throw new Error(
+              "Package declaration not found in MainApplication.kt"
+            );
+          }
           data = insertLinesHelper(
             "import com.viromedia.bridge.ReactViroPackage",
-            `package ${config?.android?.package}`,
+            packageMatch[0],
             data
           );
         }
@@ -124,7 +132,9 @@ const withBranchAndroid: ConfigPlugin<ViroConfigurationOptions> = (config) => {
               "// packages.add(MyReactNativePackage())",
               data
             );
-          } else if (data.includes("val packages = PackageList(this).packages")) {
+          } else if (
+            data.includes("val packages = PackageList(this).packages")
+          ) {
             // Handle newer format where packages is declared as val
             data = insertLinesHelper(
               target,
@@ -134,8 +144,8 @@ const withBranchAndroid: ConfigPlugin<ViroConfigurationOptions> = (config) => {
           } else {
             throw new Error(
               "Unable to insert Android packages into package list. Please create a new issue on GitHub and reference this message! " +
-              "Expected to find one of: '// packages.add(new MyReactNativePackage());', '// add(MyReactNativePackage())', " +
-              "'// packages.add(MyReactNativePackage())', or 'val packages = PackageList(this).packages'"
+                "Expected to find one of: '// packages.add(new MyReactNativePackage());', '// add(MyReactNativePackage())', " +
+                "'// packages.add(MyReactNativePackage())', or 'val packages = PackageList(this).packages'"
             );
           }
         }


### PR DESCRIPTION
Kotlin package names may contain backticks, which are not handled by the `withViroAndroid` plugin helper. 

Added regex to get exact package name from the `MainApplication.kt` file and handle it properly.