### PR TITLE
update import of AssetRegistry in ViroMaterials.ts

### DIFF
--- a/components/Material/ViroMaterials.ts
+++ b/components/Material/ViroMaterials.ts
@@ -16,8 +16,10 @@ import {
   NativeModules,
   processColor,
 } from "react-native";
+
 // @ts-ignore
-import assetRegistry from "react-native/Libraries/Image/AssetRegistry";
+import { getAssetByID } from "react-native/Libraries/Image/AssetRegistry";
+
 // @ts-ignore
 import resolveAssetSource from "react-native/Libraries/Image/resolveAssetSource";
 import { ViroSource } from "../Types/ViroUtils";
@@ -104,7 +106,7 @@ export class ViroMaterials {
           } else {
             var assetType = "unknown";
             if (typeof material[prop] !== "object") {
-              var asset = assetRegistry.getAssetByID(material[prop]);
+              var asset = getAssetByID(material[prop]);
               if (asset) {
                 assetType = asset.type;
               }


### PR DESCRIPTION
As per [this issue](https://github.com/ReactVision/viro/issues/396), it was not possible to call `ViroMaterials.createMaterials`. 

Going to the bottom of the occurring error, it appears that an invalid import was the root cause. This PR corrects the import. 

For what its worth, I have tested the fix in a project using expo 54 and react-native 0.81.4.