### PR TITLE
feat(android): add torchEnabled prop to ViroARSceneNavigator (ARCore SharedCamera)

### DIFF
--- a/android/viro_bridge/src/main/java/com/viromedia/bridge/component/VRTARSceneNavigator.java
+++ b/android/viro_bridge/src/main/java/com/viromedia/bridge/component/VRTARSceneNavigator.java
@@ -62,6 +62,8 @@ public class VRTARSceneNavigator extends VRT3DSceneNavigator {
     private DisplayRotationListener mRotationListener;
     private boolean mAutoFocusEnabled = false;
     private boolean mNeedsAutoFocusToggle = false;
+    private boolean mTorchEnabled = false;
+    private boolean mNeedsTorchToggle = false;
     private ARScene.OcclusionMode mOcclusionMode = ARScene.OcclusionMode.DISABLED;
     private boolean mNeedsOcclusionModeToggle = false;
     private boolean mDepthEnabled = false;
@@ -112,6 +114,11 @@ public class VRTARSceneNavigator extends VRT3DSceneNavigator {
             if (navigator.mNeedsAutoFocusToggle) {
                 navigator.setAutoFocusEnabled(navigator.mAutoFocusEnabled);
                 navigator.mNeedsAutoFocusToggle = false;
+            }
+
+            if (navigator.mNeedsTorchToggle) {
+                navigator.setTorchEnabled(navigator.mTorchEnabled);
+                navigator.mNeedsTorchToggle = false;
             }
 
             // Apply pending occlusion mode configuration
@@ -317,6 +324,15 @@ public class VRTARSceneNavigator extends VRT3DSceneNavigator {
             ((ViroViewARCore)mViroView).setCameraAutoFocusEnabled(mAutoFocusEnabled);
         } else {
             mNeedsAutoFocusToggle = true;
+        }
+    }
+
+    public void setTorchEnabled(boolean enabled) {
+        mTorchEnabled = enabled;
+        if (mGLInitialized) {
+            ((ViroViewARCore)mViroView).setTorchEnabled(mTorchEnabled);
+        } else {
+            mNeedsTorchToggle = true;
         }
     }
 

--- a/components/AR/ViroARSceneNavigator.tsx
+++ b/components/AR/ViroARSceneNavigator.tsx
@@ -77,6 +77,15 @@ type Props = ViewProps & {
 
   autofocus?: boolean;
   /**
+   * Enable or disable the device torch (flashlight) while the AR session is active.
+   * Requires ARCore SharedCamera mode support on the device. When supported, the torch
+   * can be toggled without interrupting the AR session. When not supported, the prop
+   * is silently ignored.
+   *
+   * Android only.
+   */
+  torchEnabled?: boolean;
+  /**
    * iOS only props! Note: these props may change as the underlying platforms coalesce in features.
    */
   worldAlignment?: "Gravity" | "GravityAndHeading" | "Camera";


### PR DESCRIPTION
## Summary

Adds a `torchEnabled` boolean prop to `ViroARSceneNavigator` on Android, allowing apps to toggle the device flashlight while an ARCore session is active.

**The problem:** `CameraManager.setTorchMode()` returns `CAMERA_IN_USE` when ARCore is running, because ARCore holds the Camera2 session exclusively. The solution is ARCore **SharedCamera mode** (`Session.Feature.SHARED_CAMERA`), where the app owns the `CameraCaptureSession` and can inject `CaptureRequest.FLASH_MODE_TORCH` into the repeating request.

## Changes in this PR (viro_bridge)

- **`components/AR/ViroARSceneNavigator.tsx`** — adds `torchEnabled?: boolean` prop with JSDoc
- **`VRTARSceneNavigatorManager.java`** — adds `@ReactProp(name = "torchEnabled")` wired to `navigator.setTorchEnabled(enabled)`
- **`VRTARSceneNavigator.java`** — adds `mTorchEnabled` / `mNeedsTorchToggle` fields and `setTorchEnabled(boolean)` method, following the same deferred-init pattern as `autofocus` / `setCameraAutoFocusEnabled`

## Required changes in viro_renderer

The bridge calls `((ViroViewARCore) mViroView).setTorchEnabled(enabled)`. The renderer needs:

### `RendererARCore.onARCoreInstalled(Context)` — try SharedCamera with fallback

```java
public void onARCoreInstalled(Context context) {
    long sessionRef = 0;
    try {
        com.google.ar.core.Session session =
            com.google.ar.core.Session.createForSharedCamera(context);
        SharedCameraState.storeSession(session);
        sessionRef = SharedCameraState.toGlobalRef(session); // JNI global ref
    } catch (Throwable e) {
        Log.w(TAG, "SharedCamera unavailable, falling back: " + e.getMessage());
        sessionRef = this.nativeCreateARCoreSession(context);
    }
    this.nativeSetARCoreSession(this.mNativeRef, sessionRef);
}
```

### `ViroViewARCore.onActivityResumed(Activity)` — open camera before session.resume() in shared mode

```java
// after requestARCoreInstall(), before mNativeRenderer.onResume():
if (SharedCameraState.isSharedCameraMode()) {
    SharedCameraState.openCameraForSharedMode(activity, () -> {
        this.mNativeRenderer.onResume();
        this.mSurfaceView.onResume();
    });
} else {
    this.mNativeRenderer.onResume();
    this.mSurfaceView.onResume();
}
```

### `ViroViewARCore.setTorchEnabled(boolean)` — new method

```java
public void setTorchEnabled(boolean enabled) {
    SharedCameraState.setTorch(enabled);
}
```

### `SharedCameraState` helper class

Stores the `Session`, `CameraDevice`, `CameraCaptureSession`, and `CaptureRequest.Builder`. Exposes:
- `storeSession(Session)` — called by patched `onARCoreInstalled`
- `isSharedCameraMode()` — checked in `onActivityResumed`
- `openCameraForSharedMode(Context, Runnable)` — opens camera via `SharedCamera` callbacks, builds initial repeating request, calls `onReady` when done
- `setTorch(boolean)` — updates `FLASH_MODE_TORCH` on the repeating request
- `toGlobalRef(Object)` / `fromGlobalRef(long)` — JNI helpers to pass `Session` as a `long` to the existing native `nativeSetARCoreSession(long, long)` signature

We have a full working reference implementation of all the above — happy to provide it if that helps.

## Behaviour

- Devices with ARCore SharedCamera support: torch works without interrupting the AR session
- Devices where `createForSharedCamera()` throws: silently falls back to standard ARCore; `torchEnabled` becomes a no-op
- Changes before GL init are queued and applied on startup (same pattern as `autofocus`)

## Test plan

- [ ] `torchEnabled={true}` on mount — LED illuminates
- [ ] Toggle `torchEnabled` at runtime — LED responds immediately
- [ ] AR session continues uninterrupted while torch is on
- [ ] Graceful no-op on devices without SharedCamera support

🤖 Generated with [Claude Code](https://claude.com/claude-code)